### PR TITLE
Refactor reliability calculation in NaiveBayesController and update c…

### DIFF
--- a/server/app/main.py
+++ b/server/app/main.py
@@ -22,12 +22,8 @@ def classify(request: dict):
     try:
         features = request.get("features", {})
         predicted = controller.classifier.classify_customer(features, controller.model)
-        reliability = controller.tester.test_model(
-            controller.model,
-            controller.cleaned_test_data,
-            controller.feature_columns,
-            controller.target_column
-        )
+        # use precomputed reliability from training
+        reliability = controller.reliability
         return {"predicted_class": predicted, "reliability": reliability}
     except Exception as e:
         return {"error": str(e)}

--- a/server/app/naive_bayes_controller.py
+++ b/server/app/naive_bayes_controller.py
@@ -20,8 +20,9 @@ class NaiveBayesController:
         self.unique_values = None
         self.feature_columns = None
         self.target_column = None
+        self.reliability = None
     
-    def load_and_prepare_data(self, file_path: str = './data/mushroom.csv'):
+    def load_and_prepare_data(self, file_path: str = './data/synthetic_500k_dataset.csv'):
         train_df, test_df = self.data_loader.load_and_split_csv(file_path, test_size=0.3, random_state=42)
         self.data = train_df
         self.test_data = test_df
@@ -38,6 +39,12 @@ class NaiveBayesController:
         self.model = self.trainer.train_model(self.cleaned_data, self.feature_columns, self.target_column)
         print("Model training completed!")
 
-        reliability = self.tester.test_model(self.model, self.cleaned_test_data, self.feature_columns, self.target_column)
+        reliability = self.tester.test_model(
+            self.model,
+            self.cleaned_test_data,
+            self.feature_columns,
+            self.target_column
+        )
+        self.reliability = reliability
         print(f"Model reliability on test data: {reliability:.2f}%")
-            
+


### PR DESCRIPTION
This pull request refactors the handling of model reliability in the `server/app` module. The changes streamline how reliability is computed and accessed, and update the default dataset used during data preparation.

### Refactoring model reliability handling:
* [`server/app/main.py`](diffhunk://#diff-108f46b2cc634dcb37f83a73943af0863c550709cb2b41948a2788c825b57541L25-R26): Updated the `classify` method to use precomputed reliability from training (`controller.reliability`) instead of recalculating it during classification.
* [`server/app/naive_bayes_controller.py`](diffhunk://#diff-e6a0e9b10572b6e53b3599fc862ab1e307d1c155efc4ba46199375c6b823a49eR23-R25): Added a new `reliability` attribute to the controller class to store precomputed reliability. The `train_model` method now computes reliability after training and assigns it to this attribute. [[1]](diffhunk://#diff-e6a0e9b10572b6e53b3599fc862ab1e307d1c155efc4ba46199375c6b823a49eR23-R25) [[2]](diffhunk://#diff-e6a0e9b10572b6e53b3599fc862ab1e307d1c155efc4ba46199375c6b823a49eL41-R48)

### Dataset update:
* [`server/app/naive_bayes_controller.py`](diffhunk://#diff-e6a0e9b10572b6e53b3599fc862ab1e307d1c155efc4ba46199375c6b823a49eR23-R25): Changed the default dataset path in the `load_and_prepare_data` method to `./data/synthetic_500k_dataset.csv` for data preparation.…lassify endpoint to use precomputed reliability